### PR TITLE
Remove native resolver support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "pin-project",
  "rustls",
  "rustls-native-certs",
- "socket2",
+ "socket2 0.6.1",
  "static_assertions",
  "thiserror",
  "tokio",
@@ -418,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -861,6 +861,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,7 +941,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -1148,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1171,6 +1181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,19 +1207,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1211,9 +1230,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1223,9 +1242,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1235,9 +1254,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1247,9 +1266,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1259,9 +1278,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1271,9 +1290,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1283,9 +1302,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1295,9 +1314,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,24 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,7 +67,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -113,21 +95,15 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.104",
+ "syn",
  "which",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
-
-[[package]]
-name = "bumpalo"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bytes"
@@ -179,20 +155,9 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
- "tracing-subscriber 0.3.20",
+ "tracing-subscriber",
  "tracing-test",
  "webpki-roots",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
 ]
 
 [[package]]
@@ -315,7 +280,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -393,30 +358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,16 +394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,9 +407,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
@@ -487,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -514,20 +445,11 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
-name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.9",
+ "regex-automata",
 ]
 
 [[package]]
@@ -582,15 +504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,7 +544,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -660,7 +573,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -682,7 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -726,17 +639,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -747,14 +651,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -818,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -850,12 +748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,9 +770,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -916,7 +808,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -982,17 +874,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
@@ -1025,7 +906,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1063,7 +944,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1135,7 +1016,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1146,17 +1027,6 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -1172,16 +1042,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
@@ -1192,36 +1052,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-serde 0.1.3",
-]
-
-[[package]]
-name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
- "matchers 0.2.0",
+ "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.9",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -1229,31 +1067,29 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
- "tracing-serde 0.2.0",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
 name = "tracing-test"
-version = "0.1.0"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b48778c2d401c6a7fcf38a0e3c55dc8e8e753cbd381044a8cdb6fd69a29f53"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
- "lazy_static",
  "tracing-core",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
  "tracing-test-macro",
 ]
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.1.0"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
- "lazy_static",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1290,65 +1126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,85 +1147,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "windows-link"
-version = "0.2.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-sys"
@@ -1456,7 +1158,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1465,7 +1167,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1474,14 +1176,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1491,10 +1210,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1503,10 +1234,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1515,10 +1258,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1527,10 +1282,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -1543,6 +1310,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,7 +113,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.104",
  "which",
 ]
 
@@ -104,6 +122,12 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -155,8 +179,20 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.20",
+ "tracing-test",
  "webpki-roots",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -279,7 +315,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -357,6 +393,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +450,16 @@ checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -444,11 +514,20 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -500,6 +579,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -572,7 +660,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -594,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -638,8 +726,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -650,8 +747,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -747,6 +850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +916,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -873,6 +982,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
@@ -905,7 +1025,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -943,7 +1063,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1015,7 +1135,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1026,6 +1146,17 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1041,6 +1172,16 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
@@ -1051,14 +1192,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers 0.0.1",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -1066,8 +1208,52 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
- "tracing-serde",
+ "tracing-log 0.1.4",
+ "tracing-serde 0.1.3",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers 0.2.0",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata 0.4.9",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-serde 0.2.0",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b48778c2d401c6a7fcf38a0e3c55dc8e8e753cbd381044a8cdb6fd69a29f53"
+dependencies = [
+ "lazy_static",
+ "tracing-core",
+ "tracing-subscriber 0.2.25",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
+dependencies = [
+ "lazy_static",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1104,6 +1290,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1367,87 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["tcp", "tower", "client", "server", "async"]
 futures = "0.3"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 pin-project = { version = "1" }
-rustls-native-certs = { version = "0.8.1", optional = true }
+rustls-native-certs = { version = "0.8.2", optional = true }
 socket2 = { version = "0.5" }
 thiserror = { version = "2" }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
@@ -45,7 +45,7 @@ static-assertions = { version = "1", package = "static_assertions" }
 webpki-roots.version = "1.0"
 pem-rfc7468 = { version = "0.7", features = ["alloc"] }
 tokio = { version = "1", features = ["macros", "time"] }
-tracing-test = "0.1"
+tracing-test = "0.2"
 
 [dev-dependencies.tracing-subscriber]
 version = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 pin-project = { version = "1" }
 rustls-native-certs = { version = "0.8.2", optional = true }
-socket2 = { version = "0.5" }
+socket2 = { version = "0.6" }
 thiserror = { version = "2" }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tokio = { version = "1", features = ["sync", "rt", "net", "io-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ static-assertions = { version = "1", package = "static_assertions" }
 webpki-roots.version = "1.0"
 pem-rfc7468 = { version = "0.7", features = ["alloc"] }
 tokio = { version = "1", features = ["macros", "time"] }
-
+tracing-test = "0.1"
 
 [dev-dependencies.tracing-subscriber]
 version = "^0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,7 @@
 yanked = "warn"
 
 [licenses]
+unused-allowed-license = "allow"
 allow = [
     "MIT",
     "Apache-2.0",
@@ -17,7 +18,7 @@ allow = [
 
 [bans]
 multiple-versions = "warn"
-skip-tree = ["windows-sys", "aws-lc-sys"]
+skip-tree = ["windows-sys"]
 
 [sources]
 unknown-registry = "warn"

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -415,7 +415,7 @@ mod tests {
         struct TestKey(String);
 
         impl Key<MockRequest> for TestKey {
-            fn build(_request: &MockRequest) -> Result<Self, crate::client::pool::KeyError> {
+            fn build_key(_request: &MockRequest) -> Result<Self, crate::client::pool::KeyError> {
                 Ok(TestKey("test".to_string()))
             }
         }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -6,15 +6,10 @@ use crate::services::SharedService;
 
 use super::conn::ConnectionError;
 use super::conn::connector::ConnectorLayer;
-use super::conn::dns::{Resolver, StaticResolver};
 use super::conn::service::ClientExecutorService;
 use super::conn::{Connection, Protocol, Transport};
 use super::pool::{Key, PoolableConnection, PoolableStream};
 use super::{ConnectionPoolLayer, PoolConfig};
-
-/// Sentinel indicating a client needs to pick a resolver.
-#[derive(Debug, Clone, Copy)]
-pub struct NeedsResolver;
 
 /// Sentinel indicating a client needs to pick a transport.
 #[derive(Debug, Clone, Copy)]
@@ -30,18 +25,16 @@ pub struct NeedsRequest;
 
 /// Builder-pattern for clients
 #[derive(Debug)]
-pub struct ClientBuilder<D, T, P, R> {
-    resolver: D,
+pub struct ClientBuilder<T, P, R> {
     transport: T,
     protocol: P,
     request: PhantomData<fn(R)>,
 }
 
-impl ClientBuilder<NeedsResolver, NeedsTransport, NeedsProtocol, NeedsRequest> {
+impl ClientBuilder<NeedsTransport, NeedsProtocol, NeedsRequest> {
     /// Create a new builder struct
     pub fn new() -> Self {
         ClientBuilder {
-            resolver: NeedsResolver,
             transport: NeedsTransport,
             protocol: NeedsProtocol,
             request: PhantomData,
@@ -49,39 +42,16 @@ impl ClientBuilder<NeedsResolver, NeedsTransport, NeedsProtocol, NeedsRequest> {
     }
 }
 
-impl Default for ClientBuilder<NeedsResolver, NeedsTransport, NeedsProtocol, NeedsRequest> {
+impl Default for ClientBuilder<NeedsTransport, NeedsProtocol, NeedsRequest> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T, P, R> ClientBuilder<NeedsResolver, T, P, R> {
-    /// Use a custom resolver
-    pub fn with_resolver<D>(self, resolver: D) -> ClientBuilder<D, T, P, R> {
-        ClientBuilder {
-            resolver,
-            transport: self.transport,
-            protocol: self.protocol,
-            request: self.request,
-        }
-    }
-
-    /// Use a static resolver, which always returns a single address.
-    pub fn with_static_address<A>(self, address: A) -> ClientBuilder<StaticResolver<A>, T, P, R> {
-        ClientBuilder {
-            resolver: StaticResolver::new(address),
-            transport: self.transport,
-            protocol: self.protocol,
-            request: self.request,
-        }
-    }
-}
-
-impl<D, P, R> ClientBuilder<D, NeedsTransport, P, R> {
+impl<P, R> ClientBuilder<NeedsTransport, P, R> {
     /// Set the selected transport
-    pub fn with_transport<T>(self, transport: T) -> ClientBuilder<D, T, P, R> {
+    pub fn with_transport<T>(self, transport: T) -> ClientBuilder<T, P, R> {
         ClientBuilder {
-            resolver: self.resolver,
             transport,
             protocol: self.protocol,
             request: self.request,
@@ -89,11 +59,10 @@ impl<D, P, R> ClientBuilder<D, NeedsTransport, P, R> {
     }
 }
 
-impl<D, T, R> ClientBuilder<D, T, NeedsProtocol, R> {
+impl<T, R> ClientBuilder<T, NeedsProtocol, R> {
     /// Set the selected protocol
-    pub fn with_protocol<P>(self, protocol: P) -> ClientBuilder<D, T, P, R> {
+    pub fn with_protocol<P>(self, protocol: P) -> ClientBuilder<T, P, R> {
         ClientBuilder {
-            resolver: self.resolver,
             transport: self.transport,
             protocol,
             request: self.request,
@@ -101,13 +70,9 @@ impl<D, T, R> ClientBuilder<D, T, NeedsProtocol, R> {
     }
 }
 
-impl<D, T, P, R> ClientBuilder<D, T, P, R>
+impl<T, P, R> ClientBuilder<T, P, R>
 where
-    D: Resolver<R> + Clone + Send + Sync + 'static,
-    D::Address: Send + Sync + 'static,
-    D::Error: Send + 'static,
-    D::Future: Send + 'static,
-    T: Transport<D::Address> + Clone + Send + Sync + 'static,
+    T: Transport<R> + Clone + Send + Sync + 'static,
     T::Future: Send + 'static,
     P: Protocol<T::IO, R> + Clone + Send + Sync + 'static,
     <P as Protocol<T::IO, R>>::Future: Send + 'static,
@@ -120,32 +85,23 @@ where
         self,
     ) -> SharedService<
         R,
-        <<P as Protocol<<T as Transport<<D as Resolver<R>>::Address>>::IO, R>>::Connection as Connection<R>>::Response,
+        <<P as Protocol<<T as Transport<R>>::IO, R>>::Connection as Connection<R>>::Response,
         ConnectionError<
-            <D as Resolver<R>>::Error,
-            <T as Transport<<D as Resolver<R>>::Address>>::Error,
-            <P as Protocol<<T as Transport<<D as Resolver<R>>::Address>>::IO, R>>::Error,
-            <<P as Protocol<<T as Transport<<D as Resolver<R>>::Address>>::IO, R>>::Connection as Connection<R>>::Error
-        >>
-    {
+            <T as Transport<R>>::Error,
+            <P as Protocol<<T as Transport<R>>::IO, R>>::Error,
+            <<P as Protocol<<T as Transport<R>>::IO, R>>::Connection as Connection<R>>::Error,
+        >,
+    > {
         tower::ServiceBuilder::new()
             .layer(SharedService::layer())
-            .layer(ConnectorLayer::new(
-                self.resolver,
-                self.transport,
-                self.protocol,
-            ))
+            .layer(ConnectorLayer::new(self.transport, self.protocol))
             .service(ClientExecutorService::new())
     }
 }
 
-impl<D, T, P, R> ClientBuilder<D, T, P, R>
+impl<T, P, R> ClientBuilder<T, P, R>
 where
-    D: Resolver<R> + Clone + Send + Sync + 'static,
-    D::Address: Send + Sync + 'static,
-    D::Error: Send + 'static,
-    D::Future: Send + 'static,
-    T: Transport<D::Address> + Clone + Send + Sync + 'static,
+    T: Transport<R> + Clone + Send + Sync + 'static,
     T::Future: Send + 'static,
     P: Protocol<T::IO, R> + Clone + Send + Sync + 'static,
     P::Connection: PoolableConnection<R>,
@@ -155,26 +111,26 @@ where
 {
     /// Build a client service with connection pooling
     #[allow(clippy::type_complexity)]
-    pub fn build_with_pool<K>(self, config: PoolConfig) -> SharedService<
+    pub fn build_with_pool<K>(
+        self,
+        config: PoolConfig,
+    ) -> SharedService<
         R,
-        <<P as Protocol<<T as Transport<<D as Resolver<R>>::Address>>::IO, R>>::Connection as Connection<R>>::Response,
+        <<P as Protocol<<T as Transport<R>>::IO, R>>::Connection as Connection<R>>::Response,
         ConnectionError<
-            <D as Resolver<R>>::Error,
-            <T as Transport<<D as Resolver<R>>::Address>>::Error,
-            <P as Protocol<<T as Transport<<D as Resolver<R>>::Address>>::IO, R>>::Error,
-            <<P as Protocol<<T as Transport<<D as Resolver<R>>::Address>>::IO, R>>::Connection as Connection<R>>::Error
-        >>
-    where K: Key<R> + Send + 'static,
+            <T as Transport<R>>::Error,
+            <P as Protocol<<T as Transport<R>>::IO, R>>::Error,
+            <<P as Protocol<<T as Transport<R>>::IO, R>>::Connection as Connection<R>>::Error,
+        >,
+    >
+    where
+        K: Key<R> + Send + 'static,
     {
         tower::ServiceBuilder::new()
             .layer(SharedService::layer())
             .layer(
-                ConnectionPoolLayer::<_, _, _, _, K>::new(
-                    self.resolver,
-                    self.transport,
-                    self.protocol,
-                )
-                .with_pool(config),
+                ConnectionPoolLayer::<_, _, _, K>::new(self.transport, self.protocol)
+                    .with_pool(config),
             )
             .service(ClientExecutorService::new())
     }
@@ -184,24 +140,22 @@ where
 mod tests {
     use super::*;
     use std::fmt::Debug;
-    use std::net::SocketAddr;
 
     use static_assertions::assert_impl_all;
 
     #[cfg(feature = "mock")]
     use crate::client::conn::protocol::mock::{MockProtocol, MockRequest, MockSender};
     #[cfg(feature = "mock")]
-    use crate::client::conn::transport::mock::{MockResolver, MockTransport};
+    use crate::client::conn::transport::mock::MockTransport;
 
     // Static assertions for sentinel types
-    assert_impl_all!(NeedsResolver: Debug, Clone, Copy, Send, Sync);
     assert_impl_all!(NeedsTransport: Debug, Clone, Copy, Send, Sync);
     assert_impl_all!(NeedsProtocol: Debug, Clone, Copy, Send, Sync);
     assert_impl_all!(NeedsRequest: Debug, Clone, Copy, Send, Sync);
 
     // Static assertions for ClientBuilder with different type states
-    assert_impl_all!(ClientBuilder<NeedsResolver, NeedsTransport, NeedsProtocol, NeedsRequest>: Debug, Default);
-    assert_impl_all!(ClientBuilder<StaticResolver<SocketAddr>, NeedsTransport, NeedsProtocol, NeedsRequest>: Debug);
+    assert_impl_all!(ClientBuilder< NeedsTransport, NeedsProtocol, NeedsRequest>: Debug, Default);
+    assert_impl_all!(ClientBuilder< NeedsTransport, NeedsProtocol, NeedsRequest>: Debug);
 
     #[cfg(feature = "mock")]
     mod mock_tests {
@@ -209,59 +163,33 @@ mod tests {
 
         // Complex static assertions for fully configured builder
         assert_impl_all!(
-            ClientBuilder<MockResolver, MockTransport, MockProtocol, MockRequest>: Debug
+            ClientBuilder< MockTransport, MockProtocol, MockRequest>: Debug
         );
 
         // Static assertions for build methods - these test the complex generic constraints
         #[allow(dead_code)]
-        type ComplexServiceType =
-            SharedService<
-                MockRequest,
-                <MockSender as Connection<MockRequest>>::Response,
-                ConnectionError<
-                    <MockResolver as Resolver<MockRequest>>::Error,
-                    <MockTransport as Transport<
-                        <MockResolver as Resolver<MockRequest>>::Address,
-                    >>::Error,
-                    <MockProtocol as Protocol<
-                        <MockTransport as Transport<
-                            <MockResolver as Resolver<MockRequest>>::Address,
-                        >>::IO,
-                        MockRequest,
-                    >>::Error,
-                    <MockSender as Connection<MockRequest>>::Error,
-                >,
-            >;
+        type ComplexServiceType = SharedService<
+            MockRequest,
+            <MockSender as Connection<MockRequest>>::Response,
+            ConnectionError<
+                <MockTransport as Transport<MockRequest>>::Error,
+                <MockProtocol as Protocol<
+                    <MockTransport as Transport<MockRequest>>::IO,
+                    MockRequest,
+                >>::Error,
+                <MockSender as Connection<MockRequest>>::Error,
+            >,
+        >;
 
         // This tests that the build_service method's return type compiles correctly
         fn _assert_build_service_type() -> ComplexServiceType {
-            let builder: ClientBuilder<MockResolver, MockTransport, MockProtocol, MockRequest> =
-                ClientBuilder {
-                    resolver: MockResolver {},
-                    transport: MockTransport::single(),
-                    protocol: MockProtocol::default(),
-                    request: std::marker::PhantomData,
-                };
+            let builder: ClientBuilder<MockTransport, MockProtocol, MockRequest> = ClientBuilder {
+                transport: MockTransport::single(),
+                protocol: MockProtocol::default(),
+                request: std::marker::PhantomData,
+            };
 
             builder.build_service()
-        }
-
-        #[test]
-        fn test_sentinel_types() {
-            let needs_resolver = NeedsResolver;
-            let needs_transport = NeedsTransport;
-            let needs_protocol = NeedsProtocol;
-            let needs_request = NeedsRequest;
-
-            let debug_resolver = format!("{needs_resolver:?}");
-            let debug_transport = format!("{needs_transport:?}");
-            let debug_protocol = format!("{needs_protocol:?}");
-            let debug_request = format!("{needs_request:?}");
-
-            assert!(debug_resolver.contains("NeedsResolver"));
-            assert!(debug_transport.contains("NeedsTransport"));
-            assert!(debug_protocol.contains("NeedsProtocol"));
-            assert!(debug_request.contains("NeedsRequest"));
         }
 
         #[test]
@@ -274,23 +202,6 @@ mod tests {
         #[test]
         fn test_client_builder_default() {
             let builder = ClientBuilder::default();
-            let debug_str = format!("{builder:?}");
-            assert!(debug_str.contains("ClientBuilder"));
-        }
-
-        #[test]
-        fn test_builder_with_resolver() {
-            let builder = ClientBuilder::new().with_resolver(MockResolver {});
-
-            let debug_str = format!("{builder:?}");
-            assert!(debug_str.contains("ClientBuilder"));
-        }
-
-        #[test]
-        fn test_builder_with_static_address() {
-            let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
-            let builder = ClientBuilder::new().with_static_address(addr);
-
             let debug_str = format!("{builder:?}");
             assert!(debug_str.contains("ClientBuilder"));
         }
@@ -314,7 +225,6 @@ mod tests {
         #[test]
         fn test_builder_method_chaining() {
             let builder = ClientBuilder::new()
-                .with_resolver(MockResolver {})
                 .with_transport(MockTransport::single())
                 .with_protocol(MockProtocol::default());
 
@@ -326,8 +236,7 @@ mod tests {
         fn test_builder_different_order_chaining() {
             let builder = ClientBuilder::new()
                 .with_protocol(MockProtocol::default())
-                .with_transport(MockTransport::single())
-                .with_resolver(MockResolver {});
+                .with_transport(MockTransport::single());
 
             let debug_str = format!("{builder:?}");
             assert!(debug_str.contains("ClientBuilder"));
@@ -335,9 +244,7 @@ mod tests {
 
         #[test]
         fn test_builder_static_address_chaining() {
-            let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
             let builder = ClientBuilder::new()
-                .with_static_address(addr)
                 .with_transport(MockTransport::reusable())
                 .with_protocol(MockProtocol::default());
 
@@ -347,13 +254,11 @@ mod tests {
 
         #[test]
         fn test_build_service() {
-            let builder: ClientBuilder<MockResolver, MockTransport, MockProtocol, MockRequest> =
-                ClientBuilder {
-                    resolver: MockResolver {},
-                    transport: MockTransport::single(),
-                    protocol: MockProtocol::default(),
-                    request: std::marker::PhantomData,
-                };
+            let builder: ClientBuilder<MockTransport, MockProtocol, MockRequest> = ClientBuilder {
+                transport: MockTransport::single(),
+                protocol: MockProtocol::default(),
+                request: std::marker::PhantomData,
+            };
 
             let service = builder.build_service();
             let debug_str = format!("{service:?}");
@@ -362,21 +267,9 @@ mod tests {
     }
 
     #[test]
-    fn test_static_resolver_integration() {
-        let addr = SocketAddr::from(([192, 168, 1, 1], 9000));
-        let static_resolver = StaticResolver::new(addr);
-
-        let builder = ClientBuilder::new().with_resolver(static_resolver);
-
-        let debug_str = format!("{builder:?}");
-        assert!(debug_str.contains("ClientBuilder"));
-    }
-
-    #[test]
     fn test_type_state_transitions() {
         // Test that the type-state machine works correctly
         let _builder_needs_all = ClientBuilder::new();
-        let _builder_has_resolver = ClientBuilder::new().with_resolver(StaticResolver::new("test"));
         let _builder_has_transport = ClientBuilder::new().with_transport(());
         let _builder_has_protocol = ClientBuilder::new().with_protocol(());
     }
@@ -391,24 +284,18 @@ mod tests {
         assert_impl_all!(MockSender: PoolableConnection<MockRequest>);
 
         // Helper type alias to test build_with_pool constraints
-        type PoolServiceType =
-            SharedService<
-                MockRequest,
-                <MockSender as Connection<MockRequest>>::Response,
-                ConnectionError<
-                    <MockResolver as Resolver<MockRequest>>::Error,
-                    <MockTransport as Transport<
-                        <MockResolver as Resolver<MockRequest>>::Address,
-                    >>::Error,
-                    <MockProtocol as Protocol<
-                        <MockTransport as Transport<
-                            <MockResolver as Resolver<MockRequest>>::Address,
-                        >>::IO,
-                        MockRequest,
-                    >>::Error,
-                    <MockSender as Connection<MockRequest>>::Error,
-                >,
-            >;
+        type PoolServiceType = SharedService<
+            MockRequest,
+            <MockSender as Connection<MockRequest>>::Response,
+            ConnectionError<
+                <MockTransport as Transport<MockRequest>>::Error,
+                <MockProtocol as Protocol<
+                    <MockTransport as Transport<MockRequest>>::IO,
+                    MockRequest,
+                >>::Error,
+                <MockSender as Connection<MockRequest>>::Error,
+            >,
+        >;
 
         // Simple key implementation for testing
         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -427,13 +314,11 @@ mod tests {
         fn _assert_build_with_pool_type() -> PoolServiceType {
             use crate::client::PoolConfig;
 
-            let builder: ClientBuilder<MockResolver, MockTransport, MockProtocol, MockRequest> =
-                ClientBuilder {
-                    resolver: MockResolver {},
-                    transport: MockTransport::reusable(),
-                    protocol: MockProtocol::default(),
-                    request: std::marker::PhantomData,
-                };
+            let builder: ClientBuilder<MockTransport, MockProtocol, MockRequest> = ClientBuilder {
+                transport: MockTransport::reusable(),
+                protocol: MockProtocol::default(),
+                request: std::marker::PhantomData,
+            };
 
             builder.build_with_pool::<TestKey>(PoolConfig::default())
         }
@@ -444,16 +329,14 @@ mod tests {
     #[test]
     fn test_generic_constraint_compilation() {
         use crate::client::conn::protocol::mock::{MockProtocol, MockRequest};
-        use crate::client::conn::transport::mock::{MockResolver, MockTransport};
+        use crate::client::conn::transport::mock::MockTransport;
 
         // This test verifies that all the complex generic constraints in the impl blocks compile correctly
-        let builder: ClientBuilder<MockResolver, MockTransport, MockProtocol, MockRequest> =
-            ClientBuilder {
-                resolver: MockResolver {},
-                transport: MockTransport::single(),
-                protocol: MockProtocol::default(),
-                request: std::marker::PhantomData,
-            };
+        let builder: ClientBuilder<MockTransport, MockProtocol, MockRequest> = ClientBuilder {
+            transport: MockTransport::single(),
+            protocol: MockProtocol::default(),
+            request: std::marker::PhantomData,
+        };
 
         // The fact that this compiles means all the trait bounds are satisfied
         let _service = builder.build_service();

--- a/src/client/conn/connector.rs
+++ b/src/client/conn/connector.rs
@@ -129,7 +129,7 @@ where
     Handshake {
         #[pin]
         future: <P as Protocol<T::IO, R>>::Future,
-        info: ConnectionInfo<D::Address>,
+        info: ConnectionInfo<<<T as Transport<D::Address>>::IO as HasConnectionInfo>::Addr>,
     },
 }
 

--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -59,11 +59,7 @@ use super::pool::KeyError;
 /// Error that can occur during the connection and serving process.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum ConnectionError<D, T, P, S> {
-    /// Error occurred during the address resolution
-    #[error("resolving address")]
-    Resolving(#[source] D),
-
+pub enum ConnectionError<T, P, S> {
     /// Error occurred during the connection
     #[error("creating connection")]
     Connecting(#[source] T),
@@ -85,10 +81,9 @@ pub enum ConnectionError<D, T, P, S> {
     Key(#[from] KeyError),
 }
 
-impl<D, T, P, S> From<connector::Error<D, T, P>> for ConnectionError<D, T, P, S> {
-    fn from(value: connector::Error<D, T, P>) -> Self {
+impl<T, P, S> From<connector::Error<T, P>> for ConnectionError<T, P, S> {
+    fn from(value: connector::Error<T, P>) -> Self {
         match value {
-            connector::Error::Resolving(d) => ConnectionError::Resolving(d),
             connector::Error::Connecting(t) => ConnectionError::Connecting(t),
             connector::Error::Handshaking(p) => ConnectionError::Handshaking(p),
             connector::Error::Unavailable => ConnectionError::Unavailable,

--- a/src/client/conn/stream/tls.rs
+++ b/src/client/conn/stream/tls.rs
@@ -11,6 +11,8 @@ use rustls::ClientConfig;
 use std::net::ToSocketAddrs;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+use crate::client::conn::transport::TlsAddr;
+use crate::client::pool::PoolableStream;
 use crate::info::TlsConnectionInfo;
 use crate::info::tls::HasTlsConnectionInfo;
 use crate::info::{ConnectionInfo, HasConnectionInfo};
@@ -47,7 +49,7 @@ where
     IO: HasConnectionInfo,
 {
     state: State<IO>,
-    info: ConnectionInfo<IO::Addr>,
+    info: ConnectionInfo<TlsAddr<IO::Addr>>,
     tls: Option<TlsConnectionInfo>,
 }
 
@@ -56,7 +58,7 @@ where
     IO: HasConnectionInfo,
     IO::Addr: Clone,
 {
-    type Addr = IO::Addr;
+    type Addr = TlsAddr<IO::Addr>;
 
     fn info(&self) -> ConnectionInfo<Self::Addr> {
         self.info.clone()
@@ -89,13 +91,19 @@ where
     IO::Addr: Clone,
 {
     /// Create a new TLS stream from the given IO, with a domain name and TLS configuration.
-    pub fn new(stream: IO, domain: &str, config: Arc<ClientConfig>) -> Self {
-        let domain = rustls::pki_types::ServerName::try_from(domain)
+    pub fn new(stream: IO, hostname: &str, config: Arc<ClientConfig>) -> Self {
+        let server_name = rustls::pki_types::ServerName::try_from(hostname)
             .expect("should be valid dns name")
             .to_owned();
 
-        let connect = tokio_rustls::TlsConnector::from(config).connect(domain, stream);
-        Self::from(connect)
+        let info = stream.info().map(|addr| TlsAddr::new(addr, hostname));
+        let connect = tokio_rustls::TlsConnector::from(config).connect(server_name, stream);
+
+        Self {
+            state: State::Handshake(Box::new(connect)),
+            info,
+            tls: None,
+        }
     }
 }
 
@@ -145,20 +153,18 @@ where
     }
 }
 
-impl<IO> From<tokio_rustls::Connect<IO>> for TlsStream<IO>
+impl<IO> PoolableStream for TlsStream<IO>
 where
-    IO: HasConnectionInfo,
-    IO::Addr: Clone,
+    IO: HasConnectionInfo + PoolableStream,
+    IO::Addr: Unpin,
 {
-    fn from(accept: tokio_rustls::Connect<IO>) -> Self {
-        let stream = accept.get_ref().expect("tls connect should have stream");
-
-        let info = stream.info();
-
-        Self {
-            state: State::Handshake(Box::new(accept)),
-            info,
-            tls: None,
+    fn can_share(&self) -> bool {
+        match &self.state {
+            State::Handshake(connect) => connect
+                .get_ref()
+                .map(|stream| stream.can_share())
+                .unwrap_or(false),
+            State::Streaming(tls_stream) => tls_stream.get_ref().0.can_share(),
         }
     }
 }

--- a/src/client/conn/stream/tls.rs
+++ b/src/client/conn/stream/tls.rs
@@ -11,7 +11,6 @@ use rustls::ClientConfig;
 use std::net::ToSocketAddrs;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use crate::client::conn::transport::TlsAddr;
 use crate::client::pool::PoolableStream;
 use crate::info::TlsConnectionInfo;
 use crate::info::tls::HasTlsConnectionInfo;
@@ -49,7 +48,7 @@ where
     IO: HasConnectionInfo,
 {
     state: State<IO>,
-    info: ConnectionInfo<TlsAddr<IO::Addr>>,
+    info: ConnectionInfo<IO::Addr>,
     tls: Option<TlsConnectionInfo>,
 }
 
@@ -58,7 +57,7 @@ where
     IO: HasConnectionInfo,
     IO::Addr: Clone,
 {
-    type Addr = TlsAddr<IO::Addr>;
+    type Addr = IO::Addr;
 
     fn info(&self) -> ConnectionInfo<Self::Addr> {
         self.info.clone()
@@ -96,7 +95,7 @@ where
             .expect("should be valid dns name")
             .to_owned();
 
-        let info = stream.info().map(|addr| TlsAddr::new(addr, hostname));
+        let info = stream.info();
         let connect = tokio_rustls::TlsConnector::from(config).connect(server_name, stream);
 
         Self {

--- a/src/client/conn/transport/mock.rs
+++ b/src/client/conn/transport/mock.rs
@@ -97,15 +97,12 @@ impl MockTransport {
     }
 
     /// Create a new connector for the transport.
-    pub fn connector(
-        self,
-        request: MockRequest,
-    ) -> Connector<MockResolver, Self, MockProtocol, MockRequest> {
-        Connector::new(MockResolver {}, self, MockProtocol::default(), request)
+    pub fn connector(self, request: MockRequest) -> Connector<Self, MockProtocol, MockRequest> {
+        Connector::new(self, MockProtocol::default(), request)
     }
 }
 
-impl tower::Service<MockAddress> for MockTransport {
+impl<Req> tower::Service<Req> for MockTransport {
     type Response = MockStream;
 
     type Error = MockConnectionError;
@@ -119,7 +116,7 @@ impl tower::Service<MockAddress> for MockTransport {
         std::task::Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, _req: MockAddress) -> Self::Future {
+    fn call(&mut self, _req: Req) -> Self::Future {
         let reuse = match &mut self.mode {
             TransportMode::SingleUse => false,
             TransportMode::Reusable => true,
@@ -153,5 +150,5 @@ mod tests {
     use static_assertions::assert_impl_all;
 
     assert_impl_all!(MockConnectionError: std::error::Error, Send, Sync);
-    assert_impl_all!(MockTransport: Transport<MockAddress>);
+    assert_impl_all!(MockTransport: Transport<()>);
 }

--- a/src/client/conn/transport/mod.rs
+++ b/src/client/conn/transport/mod.rs
@@ -15,7 +15,7 @@ use tower::Service;
 use self::oneshot::Oneshot;
 
 #[cfg(feature = "tls")]
-pub use self::tls::{StaticHostTlsTransport, TlsTransport};
+pub use self::tls::{StaticHostTlsTransport, TlsAddr, TlsAddress, TlsTransport};
 #[cfg(feature = "tls")]
 use crate::client::default_tls_config;
 
@@ -37,7 +37,7 @@ pub mod unix;
 /// an IO stream, which must be compatible with a [`super::Protocol`].
 pub trait Transport<Addr>: Send {
     /// The type of IO stream used by this transport
-    type IO: HasConnectionInfo<Addr = Addr> + Send + 'static;
+    type IO: HasConnectionInfo + Send + 'static;
 
     /// Error returned when connection fails
     type Error: std::error::Error + Send + Sync + 'static;
@@ -63,7 +63,7 @@ where
     T: Clone + Send + Sync + 'static,
     T::Error: std::error::Error + Send + Sync + 'static,
     T::Future: Send + 'static,
-    IO: HasConnectionInfo<Addr = Addr> + Send + 'static,
+    IO: HasConnectionInfo + Send + 'static,
     Addr: Send,
 {
     type IO = IO;

--- a/src/client/conn/transport/tcp.rs
+++ b/src/client/conn/transport/tcp.rs
@@ -28,6 +28,38 @@ use crate::client::conn::dns::{IpVersion, SocketAddrs};
 use crate::happy_eyeballs::{EyeballSet, HappyEyeballsError};
 use crate::stream::tcp::TcpStream;
 
+/// A trait for resolving a TCP address from a request.
+pub trait TcpResolver<Req> {
+    /// Error returned when TCP resolution fails
+    type Error;
+
+    /// Future used to resovle TCP addresses
+    type Future: Future<Output = Result<SocketAddrs, Self::Error>>;
+
+    /// Check if the resolver is ready to resovle.
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+
+    /// Return a future to resolve an address.
+    fn resolve(&mut self, req: Req) -> Self::Future;
+}
+
+impl<T, Req> TcpResolver<Req> for T
+where
+    T: tower::Service<Req, Response = SocketAddrs>,
+{
+    type Error = T::Error;
+
+    type Future = T::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        <T as tower::Service<Req>>::poll_ready(self, cx)
+    }
+
+    fn resolve(&mut self, req: Req) -> Self::Future {
+        self.call(req)
+    }
+}
+
 /// A TCP connector for client connections.
 ///
 /// This type is a [`tower::Service`] that connects to remote addresses using TCP.
@@ -46,32 +78,28 @@ use crate::stream::tcp::TcpStream;
 /// remote addresses, which allows for faster connection times by trying
 /// multiple addresses in parallel, regardless of whether they are IPv4 or IPv6.
 #[derive(Debug)]
-pub struct TcpTransport {
+pub struct TcpTransport<R> {
+    resolver: R,
     config: Arc<TcpTransportConfig>,
 }
 
-impl Clone for TcpTransport {
+impl<R: Clone> Clone for TcpTransport<R> {
     fn clone(&self) -> Self {
         Self {
+            resolver: self.resolver.clone(),
             config: self.config.clone(),
         }
     }
 }
 
-impl Default for TcpTransport {
-    fn default() -> Self {
-        TcpTransport::new(TcpTransportConfig::default().into())
-    }
-}
-
-impl TcpTransport {
+impl<R> TcpTransport<R> {
     /// Create a new TCP transport
-    pub fn new(config: Arc<TcpTransportConfig>) -> Self {
-        Self { config }
+    pub fn new(resolver: R, config: Arc<TcpTransportConfig>) -> Self {
+        Self { resolver, config }
     }
 }
 
-impl TcpTransport {
+impl<R> TcpTransport<R> {
     /// Get the configuration for the TCP connector.
     pub fn config(&self) -> &TcpTransportConfig {
         &self.config
@@ -80,7 +108,12 @@ impl TcpTransport {
 
 type BoxFuture<'a, T, E> = crate::BoxFuture<'a, Result<T, E>>;
 
-impl tower::Service<SocketAddrs> for TcpTransport {
+impl<Resolver, Request> tower::Service<Request> for TcpTransport<Resolver>
+where
+    Resolver: TcpResolver<Request> + Clone + Send + 'static,
+    Resolver::Error: std::error::Error + Send + Sync + 'static,
+    Resolver::Future: Send + 'static,
+{
     type Response = TcpStream;
     type Error = TcpConnectionError;
     type Future = BoxFuture<'static, Self::Response, Self::Error>;
@@ -89,14 +122,18 @@ impl tower::Service<SocketAddrs> for TcpTransport {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: SocketAddrs) -> Self::Future {
-        let transport = std::mem::replace(self, self.clone());
-
+    fn call(&mut self, req: Request) -> Self::Future {
+        let config = self.config.clone();
         let span = tracing::trace_span!("tcp");
+
+        let resolve = self.resolver.resolve(req);
 
         Box::pin(
             async move {
-                let stream = transport.connecting(req).connect().await?;
+                let addrs = resolve
+                    .await
+                    .map_err(TcpConnectionError::msg("resolving"))?;
+                let stream = config.connecting(addrs).connect().await?;
 
                 if let Ok(peer_addr) = stream.peer_addr() {
                     trace!(peer.addr = %peer_addr, "tcp connected");
@@ -111,32 +148,25 @@ impl tower::Service<SocketAddrs> for TcpTransport {
     }
 }
 
-impl tower::Service<SocketAddr> for TcpTransport {
-    type Response = <Self as tower::Service<SocketAddrs>>::Response;
-    type Error = <Self as tower::Service<SocketAddrs>>::Error;
-    type Future = <Self as tower::Service<SocketAddrs>>::Future;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        <Self as tower::Service<SocketAddrs>>::poll_ready(self, cx)
-    }
-
-    fn call(&mut self, req: SocketAddr) -> Self::Future {
-        let addrs = SocketAddrs::from(req);
-        <Self as tower::Service<SocketAddrs>>::call(self, addrs)
-    }
-}
-
-impl TcpTransport {
+impl TcpTransportConfig {
     /// Create a new `TcpConnecting` future.
     fn connecting(&self, mut addrs: SocketAddrs) -> TcpConnecting<'_> {
-        if self.config.happy_eyeballs_timeout.is_some() {
+        if self.happy_eyeballs_timeout.is_some() {
             addrs.sort_preferred(IpVersion::from_binding(
-                self.config.local_address_ipv4,
-                self.config.local_address_ipv6,
+                self.local_address_ipv4,
+                self.local_address_ipv6,
             ));
         }
 
-        TcpConnecting::new(addrs, &self.config)
+        TcpConnecting::new(addrs, &self)
+    }
+
+    /// Connect to a single address
+    async fn connect_to_addr(&self, addr: SocketAddr) -> Result<TcpStream, TcpConnectionError> {
+        let connect = connect(&addr, self.connect_timeout, &self)?;
+        connect
+            .await
+            .map_err(TcpConnectionError::msg("tcp connect error"))
     }
 }
 
@@ -369,43 +399,42 @@ impl Default for TcpTransportConfig {
 }
 
 /// A simple TCP transport that uses a single connection attempt.
-pub struct SimpleTcpTransport {
+pub struct SimpleTcpTransport<R> {
+    resolver: R,
     config: Arc<TcpTransportConfig>,
 }
 
-impl fmt::Debug for SimpleTcpTransport {
+impl<R> fmt::Debug for SimpleTcpTransport<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SimpleTcpTransport").finish()
     }
 }
 
-impl Clone for SimpleTcpTransport {
+impl<R: Clone> Clone for SimpleTcpTransport<R> {
     fn clone(&self) -> Self {
         Self {
+            resolver: self.resolver.clone(),
             config: self.config.clone(),
         }
     }
 }
 
-impl SimpleTcpTransport {
+impl<R> SimpleTcpTransport<R> {
     /// Create a new simple TCP transport with the given configuration and resolver.
-    pub fn new(config: TcpTransportConfig) -> Self {
+    pub fn new(resolver: R, config: TcpTransportConfig) -> Self {
         Self {
+            resolver,
             config: Arc::new(config),
         }
     }
 }
 
-impl SimpleTcpTransport {
-    async fn connect_to_addr(&self, addr: SocketAddr) -> Result<TcpStream, TcpConnectionError> {
-        let connect = connect(&addr, self.config.connect_timeout, &self.config)?;
-        connect
-            .await
-            .map_err(TcpConnectionError::msg("tcp connect error"))
-    }
-}
-
-impl tower::Service<SocketAddr> for SimpleTcpTransport {
+impl<R, Request> tower::Service<Request> for SimpleTcpTransport<R>
+where
+    R: TcpResolver<Request> + Clone + Send + 'static,
+    R::Error: std::error::Error + Send + Sync + 'static,
+    R::Future: Send + 'static,
+{
     type Response = TcpStream;
     type Error = TcpConnectionError;
     type Future = BoxFuture<'static, Self::Response, Self::Error>;
@@ -414,13 +443,30 @@ impl tower::Service<SocketAddr> for SimpleTcpTransport {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: SocketAddr) -> Self::Future {
-        let transport = std::mem::replace(self, self.clone());
+    fn call(&mut self, req: Request) -> Self::Future {
+        let transport = self.config.clone();
 
-        let span = tracing::trace_span!("tcp", ip = %req.ip(), port = %req.port());
+        let span = tracing::trace_span!(
+            "tcp",
+            ip = tracing::field::Empty,
+            port = tracing::field::Empty
+        );
+        let resolve = self.resolver.resolve(req);
 
+        let span_handle = span.clone();
         async move {
-            let stream = transport.connect_to_addr(req).await?;
+            let mut addrs = resolve
+                .await
+                .map_err(TcpConnectionError::msg("resolving"))?;
+
+            let addr = addrs
+                .pop()
+                .ok_or_else(|| TcpConnectionError::new("No address found"))?;
+
+            span_handle.record("ip", addr.ip().to_string());
+            span_handle.record("port", addr.port());
+
+            let stream = transport.connect_to_addr(addr).await?;
 
             if let Ok(peer_addr) = stream.peer_addr() {
                 trace!(peer.addr = %peer_addr, "tcp connected");
@@ -541,6 +587,8 @@ pub(crate) fn connect(
 #[cfg(test)]
 mod test {
 
+    use std::convert::Infallible;
+
     use tokio::net::TcpListener;
     use tower::{Service, ServiceExt as _};
 
@@ -548,16 +596,42 @@ mod test {
 
     use super::*;
 
-    async fn connect_transport<T, R>(
-        addr: R,
-        transport: T,
-        listener: TcpListener,
-    ) -> (TcpStream, TcpStream)
+    #[derive(Debug, Clone)]
+    struct MockResolver<A> {
+        addr: A,
+    }
+
+    impl<A> MockResolver<A> {
+        fn new(addr: A) -> Self {
+            Self { addr }
+        }
+    }
+
+    impl<A, R> tower::Service<R> for MockResolver<A>
     where
-        T: Service<R, Response = TcpStream>,
-        <T as Service<R>>::Error: std::fmt::Debug,
+        A: Clone,
     {
-        tokio::join!(async { transport.oneshot(addr).await.unwrap() }, async {
+        type Response = A;
+
+        type Error = Infallible;
+
+        type Future = std::future::Ready<Result<A, Infallible>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: R) -> Self::Future {
+            std::future::ready(Ok(self.addr.clone()))
+        }
+    }
+
+    async fn connect_transport<T>(transport: T, listener: TcpListener) -> (TcpStream, TcpStream)
+    where
+        T: Service<(), Response = TcpStream>,
+        <T as Service<()>>::Error: std::fmt::Debug,
+    {
+        tokio::join!(async { transport.oneshot(()).await.unwrap() }, async {
             let (stream, addr) = listener.accept().await.unwrap();
             TcpStream::server(stream, addr)
         })
@@ -572,14 +646,12 @@ mod test {
 
         let config = TcpTransportConfig::default();
 
-        let transport = TcpTransport::new(config.into());
+        let transport = TcpTransport::new(
+            MockResolver::new(SocketAddrs::from(bind.local_addr().unwrap())),
+            config.into(),
+        );
 
-        let (stream, _) = connect_transport(
-            SocketAddrs::from(bind.local_addr().unwrap()),
-            transport,
-            bind,
-        )
-        .await;
+        let (stream, _) = connect_transport(transport, bind).await;
 
         let info = stream.info();
         assert_eq!(
@@ -592,29 +664,20 @@ mod test {
     async fn test_transport_connect_to_addrs() {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let bind = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = bind.local_addr().unwrap().port();
-
-        let config = TcpTransportConfig::default();
-        let transport = TcpTransport::new(config.into());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
 
         let addrs = vec![
             SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port),
             SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port + 1),
         ];
 
-        let (conn, _): (TcpStream, TcpStream) = tokio::join!(
-            async {
-                transport
-                    .oneshot(SocketAddrs::from_iter(addrs.into_iter()))
-                    .await
-                    .unwrap()
-            },
-            async {
-                let (stream, addr) = bind.accept().await.unwrap();
-                TcpStream::server(stream, addr)
-            }
-        );
+        let resolver = MockResolver::new(SocketAddrs::from_iter(addrs.into_iter()));
+
+        let config = TcpTransportConfig::default();
+        let transport = TcpTransport::new(resolver, config.into());
+
+        let (conn, _): (TcpStream, TcpStream) = connect_transport(transport, listener).await;
 
         let info = conn.info();
         assert_eq!(
@@ -627,13 +690,16 @@ mod test {
     async fn test_simple_transport() {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let bind = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = bind.local_addr().unwrap().port();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
 
         let config = TcpTransportConfig::default();
-        let transport = SimpleTcpTransport::new(config);
+        let transport = SimpleTcpTransport::new(
+            MockResolver::new(SocketAddrs::from(listener.local_addr().unwrap())),
+            config,
+        );
 
-        let (conn, _) = connect_transport(bind.local_addr().unwrap(), transport, bind).await;
+        let (conn, _) = connect_transport(transport, listener).await;
 
         let info = conn.info();
         assert_eq!(

--- a/src/client/conn/transport/tcp.rs
+++ b/src/client/conn/transport/tcp.rs
@@ -167,12 +167,12 @@ impl TcpTransportConfig {
             ));
         }
 
-        TcpConnecting::new(addrs, &self)
+        TcpConnecting::new(addrs, self)
     }
 
     /// Connect to a single address
     async fn connect_to_addr(&self, addr: SocketAddr) -> Result<TcpStream, TcpConnectionError> {
-        let connect = connect(&addr, self.connect_timeout, &self)?;
+        let connect = connect(&addr, self.connect_timeout, self)?;
         connect
             .await
             .map_err(TcpConnectionError::msg("tcp connect error"))

--- a/src/client/conn/transport/tcp.rs
+++ b/src/client/conn/transport/tcp.rs
@@ -92,6 +92,15 @@ impl<R: Clone> Clone for TcpTransport<R> {
     }
 }
 
+impl<R: Default> Default for TcpTransport<R> {
+    fn default() -> Self {
+        Self {
+            resolver: R::default(),
+            config: Arc::new(TcpTransportConfig::default()),
+        }
+    }
+}
+
 impl<R> TcpTransport<R> {
     /// Create a new TCP transport
     pub fn new(resolver: R, config: Arc<TcpTransportConfig>) -> Self {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,6 @@ use crate::services::SharedService;
 
 use self::builder::NeedsProtocol;
 use self::builder::NeedsRequest;
-use self::builder::NeedsResolver;
 use self::builder::NeedsTransport;
 pub use self::pool::Config as PoolConfig;
 pub use self::pool::service::ConnectionPoolLayer;
@@ -46,8 +45,7 @@ impl<Req, Res, Err> Client<Req, Res, Err> {
     }
 
     /// Create a new client builder
-    pub fn builder()
-    -> builder::ClientBuilder<NeedsResolver, NeedsTransport, NeedsProtocol, NeedsRequest> {
+    pub fn builder() -> builder::ClientBuilder<NeedsTransport, NeedsProtocol, NeedsRequest> {
         builder::ClientBuilder::new()
     }
 }

--- a/src/client/pool/mod.rs
+++ b/src/client/pool/mod.rs
@@ -58,10 +58,20 @@ pub struct KeyError {
     inner: BoxError,
 }
 
+impl KeyError {
+    /// Create a new `KeyError` from an error
+    pub fn new<E>(err: E) -> Self
+    where
+        E: Into<BoxError>,
+    {
+        Self { inner: err.into() }
+    }
+}
+
 /// Key which links an address and request to a connection.
 pub trait Key<R>: Eq + std::hash::Hash + fmt::Debug {
     /// Build a pool key from an address and request
-    fn build(request: &R) -> Result<Self, KeyError>
+    fn build_key(request: &R) -> Result<Self, KeyError>
     where
         Self: Sized;
 }
@@ -708,7 +718,7 @@ mod tests {
     struct MockKey;
 
     impl super::Key<MockRequest> for MockKey {
-        fn build(_: &MockRequest) -> Result<Self, KeyError>
+        fn build_key(_: &MockRequest) -> Result<Self, KeyError>
         where
             Self: Sized,
         {

--- a/src/client/pool/mod.rs
+++ b/src/client/pool/mod.rs
@@ -170,7 +170,7 @@ where
         connector: Connector<T, P, R>,
     ) -> Checkout<T, P, R>
     where
-        T: Transport<R>,
+        T: Transport<R> + Send,
         P: Protocol<T::IO, R, Connection = C> + Send + 'static,
         C: PoolableConnection<R>,
     {

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -211,7 +211,7 @@ where
         Checkout<D, T, P, R>,
         ConnectionError<D::Error, T::Error, <P as Protocol<T::IO, R>>::Error, S::Error>,
     > {
-        let key: K = K::build(&request)?;
+        let key: K = K::build_key(&request)?;
         let resolver = self.resolver.clone();
         let protocol = self.protocol.clone();
         let transport = self.transport.clone();

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -176,7 +176,7 @@ where
 
 impl<T, P, S, R, K> ConnectionPoolService<T, P, S, R, K>
 where
-    T: Transport<R> + Clone,
+    T: Transport<R> + Clone + Send,
     T::IO: Unpin,
     P: Protocol<T::IO, R> + Clone + Send + Sync + 'static,
     <P as Protocol<T::IO, R>>::Connection: PoolableConnection<R> + Send + 'static,

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -75,3 +75,10 @@ pub trait HasConnectionInfo {
     /// Get the connection information for this stream.
     fn info(&self) -> ConnectionInfo<Self::Addr>;
 }
+
+#[cfg(not(feature = "tls"))]
+/// Trait for types which can provide TLS connection information, not populated without the `tls` feature.
+pub trait HasTlsConnectionInfo {}
+
+#[cfg(not(feature = "tls"))]
+impl<T> HasTlsConnectionInfo for T where T: HasConnectionInfo {}

--- a/src/info/tls.rs
+++ b/src/info/tls.rs
@@ -86,6 +86,16 @@ pub trait HasTlsConnectionInfo: HasConnectionInfo {
     fn tls_info(&self) -> Option<&TlsConnectionInfo>;
 }
 
+#[cfg(not(feature = "tls"))]
+impl<T> HasTlsConnectionInfo for T
+where
+    T: HasConnectionInfo,
+{
+    fn tls_info(&self) -> Option<&TlsConnectionInfo> {
+        None
+    }
+}
+
 #[cfg(feature = "server")]
 mod channel {
     use std::{

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,8 +13,8 @@ use crate::BoxError;
 use crate::{notify, services::MakeServiceRef};
 
 pub use self::builder::{NeedsAcceptor, NeedsExecutor, NeedsProtocol, NeedsService};
-use self::conn::drivers::{ConnectionDriver, ServerExecutor};
-use self::conn::drivers::{GracefulConnectionDriver, GracefulServerExecutor};
+pub use self::conn::drivers::{ConnectionDriver, ServerExecutor};
+pub use self::conn::drivers::{GracefulConnectionDriver, GracefulServerExecutor};
 
 /// Trait for accepting new connections from raw streams.
 pub use self::conn::Accept;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,15 +1,9 @@
 //! General tower services used for composition in this module.
 
-#[cfg(feature = "client")]
-mod addressable;
 mod make;
 mod serviceref;
 mod shared;
 
-#[cfg(feature = "client")]
-pub use self::addressable::{
-    ResolvedAddressableFuture, ResolvedAddressableLayer, ResolvedAddressableService,
-};
 pub use self::make::{BoxMakeServiceLayer, BoxMakeServiceRef, MakeServiceRef, make_service_fn};
 pub use self::serviceref::ServiceRef;
 pub use self::shared::SharedService;

--- a/src/stream/duplex.rs
+++ b/src/stream/duplex.rs
@@ -34,6 +34,9 @@ use std::{
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 
+#[cfg(feature = "client")]
+use crate::client::pool::PoolableStream;
+
 use crate::info::{self, HasConnectionInfo};
 
 #[cfg(feature = "server")]
@@ -99,6 +102,13 @@ impl DuplexStream {
             },
             DuplexStream { inner: b, info },
         )
+    }
+}
+
+#[cfg(feature = "client")]
+impl PoolableStream for DuplexStream {
+    fn can_share(&self) -> bool {
+        false
     }
 }
 

--- a/src/stream/tcp.rs
+++ b/src/stream/tcp.rs
@@ -18,6 +18,8 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 pub use tokio::net::TcpListener;
 
+#[cfg(feature = "client")]
+use crate::client::pool::PoolableStream;
 use crate::info::HasConnectionInfo;
 #[cfg(feature = "server")]
 use crate::server::Accept;
@@ -176,6 +178,13 @@ impl HasConnectionInfo for TcpStream {
                 .expect("local_addr is available for stream"),
             remote_addr,
         }
+    }
+}
+
+#[cfg(feature = "client")]
+impl PoolableStream for TcpStream {
+    fn can_share(&self) -> bool {
+        false
     }
 }
 

--- a/src/stream/unix.rs
+++ b/src/stream/unix.rs
@@ -19,6 +19,8 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 pub use tokio::net::UnixListener;
 
+#[cfg(feature = "client")]
+use crate::client::pool::PoolableStream;
 use crate::info::HasConnectionInfo;
 #[cfg(feature = "server")]
 use crate::server::Accept;
@@ -174,6 +176,13 @@ impl HasConnectionInfo for UnixStream {
             local_addr,
             remote_addr,
         }
+    }
+}
+
+#[cfg(feature = "client")]
+impl PoolableStream for UnixStream {
+    fn can_share(&self) -> bool {
+        false
     }
 }
 


### PR DESCRIPTION
Not all connection types should require resolvers, it makes sense more in a connection like TCP, where we might use DNS to identify the destination address, but doesn't make sense for Unix transports or Duplex/in-memory transports.